### PR TITLE
Get the first of multiple headers

### DIFF
--- a/src/basic.lua
+++ b/src/basic.lua
@@ -143,7 +143,7 @@ function _M.serialize(ngx, kong, conf)
       request = {
           request = temp_request,
           method = kong.request.get_method(),
-          Optum_CID_Ext = req.get_headers()["optum-cid-ext"],
+          Optum_CID_Ext = req.get_headers(1)["optum-cid-ext"],
           ["in"] = tonumber(var.request_length), --in is reserved word and must wrap it like so
           out = tonumber(var.bytes_sent)
       }


### PR DESCRIPTION
We want the Optum_CID_Ext field to be a singular value, if users pass multiple headers it ends up in the kafka deadletter queue.